### PR TITLE
opengp::glfwTrackball inline

### DIFF
--- a/external/OpenGP/GL/glfw_trackball.h
+++ b/external/OpenGP/GL/glfw_trackball.h
@@ -155,7 +155,7 @@ namespace{
     }
 }
 
-void glfwTrackball(void (*update_matrices)(const Eigen::Matrix4f& )){
+inline void glfwTrackball(void (*update_matrices)(const Eigen::Matrix4f& )){
     hook_trackball_callbacks(update_matrices);
 }
 


### PR DESCRIPTION
opengp::glfwTrackball is defined in a header and was nonetheless not marked inline thus giving it external linkage.  This caused link time errors (multiple definitions of the same symbol) when linking a program or library which included the header containing opengp::glfwTrackball in multiple translation units.

Marked opengp::glfwTrackball inline to rectify this.
